### PR TITLE
refactor: enable full AT scope except backup tests

### DIFF
--- a/templates/kafka-service/kafka_clean_sc_zoo_s3.yml
+++ b/templates/kafka-service/kafka_clean_sc_zoo_s3.yml
@@ -60,5 +60,5 @@ backupDaemon:
 integrationTests:
   install: true
   waitForResult: true
-  tags: kafka_crudORkafka_imagesORkafka_haORkafka_consumer_producerORrebalanceORacl
+  tags: kafkaNOTbackup
   zookeeperOsProject: "zookeeper"


### PR DESCRIPTION
Extends test tags to cover larger number of test scenarios according to https://github.com/Netcracker/qubership-kafka/blob/main/docs/public/installation.md#integration-test-tags-description:
```
integrationTests:
  install: true
  waitForResult: true
  tags: kafkaNOTbackup
  ```