### PR TITLE
fix: rewrite logic of using ADDITIONAL_SUCCESS_MESSAGES variable

### DIFF
--- a/actions/shared/verify_installation/action.yml
+++ b/actions/shared/verify_installation/action.yml
@@ -110,17 +110,13 @@ runs:
           for i in {1..${{inputs.max_attempts_for_provisioner}}}; do
             cr_yaml=$(kubectl get "${{inputs.cr_kind}}" "${{inputs.cr_name}}" -n "${{inputs.namespace}}" -o yaml)
             IFS='|' read -ra messages <<< "${{ inputs.ADDITIONAL_SUCCESS_MESSAGES }}"
-            # Build the yq expression safely
             yq_expr='.status.conditions[] | select(.reason == "ReconcileCycleStatus"'
             for msg in "${messages[@]}"; do
-              msg="$(echo "$msg" | xargs)"  # trim whitespace
-              esc_msg=$(printf '%s' "$msg" | sed 's/"/\\"/g') # escape quotes
+              msg="$(echo "$msg" | xargs)"
+              esc_msg=$(printf '%s' "$msg" | sed 's/"/\\"/g')
               yq_expr+=" or .message == \"$esc_msg\""
             done
             yq_expr+=")"
-            # Debug log
-            echo "Constructed yq expression: $yq_expr"
-            # Evaluate condition safely using variable expansion
             condition=$(echo "$cr_yaml" | yq eval "$yq_expr" -o=json)
             if [[ -n "$condition" ]]; then
               status=$(echo "$condition" | yq eval '.status' -)


### PR DESCRIPTION
`yq eval ".status.conditions[]` should be refactored
Closes https://github.com/Netcracker/qubership-test-pipelines/issues/67