### PR TITLE
feat: preparation to selective build

### DIFF
--- a/actions/shared/helm_deploy/action.yml
+++ b/actions/shared/helm_deploy/action.yml
@@ -169,7 +169,7 @@ runs:
     - name: Update versions in values
       id: update-versions
       if: ${{ steps.check-release.outputs.is_release == 'false' }}
-      uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@496-feat-implement-selective-build-deploy-and-test-ci-approach-for-kafka
+      uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@3e428f45132119ce49d90f3770a45d4fe1d1078d  # v2.0.4
       with:
         release-version: ${{steps.replace_slash.outputs.service_branch_updated}}
         config-file: .github/charts-values-update-config.yaml


### PR DESCRIPTION
https://github.com/Netcracker/qubership-workflow-hub/issues/496

Switched `netcracker/qubership-workflow-hub/actions/charts-values-update-action` version to `v2.0.4` where implemented substitution of `default-tag` parameter if `release-version` not found for the image.

It is needed for selective build on changes.