### PR TITLE
chore(ci): update of CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,69 +1,34 @@
-# How to implement the workflow in repository
-# Create a .github/workflows/cla.yaml file in the repository and copy code below
-# ###################################################
-# name: CLA Assistant
-# on:
-#   issue_comment:
-#     types: [created]
-#   pull_request_target:
-#     types: [opened,closed,synchronize]
-# jobs:
-#   cla_assistant:
-#     uses: Netcracker/qubership-github-workflows/.github/workflows/cla.yaml@main
-#     secrets:
-#       personal_access_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-# ###################################################
-# PERSONAL_ACCESS_TOKEN should be created for Netcracker/cla-storage with repository permissions
-# - Read access to metadata
-# - Read and Write access to code, merge queues and pull requests
-# PERSONAL_ACCESS_TOKEN Actions secret should be added on organization level to be accesible by workflows in all repositories.
-
-name: "CLA Assistant"
+---
+name: CLA Assistant
 on:
-  workflow_call:
-    secrets:
-      personal_access_token:
-        required: true
-#  issue_comment:
-#    types: [created]
-#  pull_request_target:
-#    types: [opened,closed,synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened]
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: write
-  contents: read # this can be 'read' if the signatures are in remote repository
-  pull-requests: write
-  statuses: write
+  contents: read
 
 jobs:
   CLAAssistant:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: Netcracker/qubership-workflow-hub/actions/cla-assistant@e64a1ee2fc2f68ab44a4ef416c27d83ce36ba8e1 # v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.personal_access_token }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/Netcracker/qubership-github-workflows/blob/main/CLA/cla.md'
+          path-to-document: 'https://github.com/Netcracker/qubership-workflow-hub/blob/release/v2.2.0/CLA/cla.md'
           # branch should not be protected
           branch: 'main'
           allowlist: NetcrackerCLPLCI,web-flow,bot*
           remote-repository-name: cla-storage
           remote-organization-name: Netcracker
-
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA


### PR DESCRIPTION
Switching to our own copy of the CLAAssistant action, as the original action has been archived. Plus, our version has been rewritten for Node.24.