### PR TITLE
fix(actions/shared): fix action inputs, security issues and add READMEs

### DIFF
--- a/actions/shared/collect_diag_info/README.md
+++ b/actions/shared/collect_diag_info/README.md
@@ -1,0 +1,167 @@
+# 🚀 Collect Diagnostics Action
+
+GitHub Action to collect logs, resource manifests, and artifacts from a Kubernetes namespace
+and upload them as a workflow artifact for post-deploy or post-failure investigation.
+
+---
+
+## Features
+
+- Creates an `artifacts/` working directory for all collected files
+- Collects pod list, per-pod YAML manifests, namespace events, PVC and PV information
+- Captures container logs for all containers in all pods, with a pending-retry loop
+  (up to 300 seconds) for containers that are not yet running or terminated
+- Captures previous-run logs for containers that have restarted at least once
+- Lists all resources (`kubectl get all`) and secret names in the namespace
+- Optionally collects VictoriaMetrics Custom Resource YAML files for monitoring pipelines
+- Generates a timestamped artifact name automatically, or uses a caller-supplied name
+- Uploads all collected files as a single GitHub Actions artifact
+
+---
+
+## 📌 Inputs
+
+| Name | Description | Required | Default |
+|---|---|---|---|
+| `namespace` | Kubernetes namespace to collect diagnostics from. | Yes | - |
+| `service_branch` | Branch or tag name of the service being tested. Used in the auto-generated artifact name — slashes are replaced with underscores, whitespace is stripped. Ignored when `artifact_name` is provided. | No | - |
+| `artifact_name` | Custom base name for the uploaded artifact. When provided, the final name is `<artifact_name>_<timestamp>`. When empty, the name is generated as `<job>_<namespace>_<branch>_<version>_artifacts_<timestamp>`. | No | `""` |
+| `version` | Matrix dimension value (e.g. `${{ matrix.service_image }}`) appended as a suffix in the auto-generated artifact name. Has no effect when `artifact_name` is provided. | No | `""` |
+| `monitoring_pipeline` | When `true`, dumps VictoriaMetrics CRs (`VMAlertManager`, `VMAlert`, `VMAgent`, `VMSingle`, `VMAuth`, `PlatformMonitoring`) as YAML files into `artifacts/`. | No | `false` |
+
+---
+
+## 📌 Outputs
+
+This action produces no step outputs. All collected data is uploaded as a workflow artifact
+whose name is derived from the inputs (see Additional Information).
+
+---
+
+## How it works
+
+The action gathers diagnostics in the following order, with most steps running under
+`if: always()` so they execute even when previous steps failed:
+
+1. **Monitoring resources** (only when `monitoring_pipeline: true`, runs under `if: always()`): exports six
+   VictoriaMetrics and `PlatformMonitoring` CRs as YAML files into `artifacts/`.
+2. **Pod list**: runs `kubectl get pods` and saves output to
+   `artifacts/<namespace>_get_pods.txt`.
+3. **Pod YAML manifests**: saves each pod's full YAML to
+   `artifacts/pod_yamls/<pod-name>.yaml`. Failures write a `_FAILED.txt` marker instead.
+4. **Namespace events**: saves `kubectl events` output to
+   `artifacts/<namespace>_get_events.txt`.
+5. **PVC YAML**: saves all PersistentVolumeClaim manifests to
+   `artifacts/<namespace>_get_pvc_yaml.yaml`.
+6. **PV list**: filters cluster-wide PVs for those bound to the namespace and saves to
+   `artifacts/<namespace>_get_pv.txt`.
+7. **Container logs**: for every container in every pod, collects current logs to
+   `artifacts/logs/<pod>__<container>.log`. Containers not yet in `running` or `terminated`
+   state are queued and retried every 5 seconds until ready or the 300-second hard timeout
+   is reached. Containers with `restartCount > 0` also get their previous logs saved to
+   `artifacts/logs/<pod>__<container>__previous.log`.
+8. **All resources**: prints `kubectl get all` to the workflow log (not saved to a file).
+9. **Secrets list**: prints `kubectl get secrets` to the log (names only, not values).
+10. **Artifact upload**: generates a timestamped artifact name and uploads the entire
+    `artifacts/` folder via `actions/upload-artifact@v4`.
+
+---
+
+## Additional Information
+
+### Artifact naming
+
+When `artifact_name` is empty (the default), the artifact name is built as:
+
+```text
+<github.job>_<namespace>_<service_branch>_<version>_artifacts_<YYYYMMDDHHmmssSSS>
+```
+
+- `service_branch` has whitespace stripped and `/` replaced with `_`.
+- `<version>_` is included only when the `version` input is non-empty.
+- The timestamp uses UTC with millisecond precision.
+
+When `artifact_name` is provided, the name is:
+
+```text
+<artifact_name>_<YYYYMMDDHHmmssSSS>
+```
+
+Slashes in `artifact_name` are replaced with `_`.
+
+### Container log collection
+
+The log-collection step uses a two-pass approach:
+
+- **First pass**: iterates all pods and containers. Running or terminated containers have
+  logs collected immediately. All others are added to a pending list.
+- **Retry loop**: pending containers are re-checked every 5 seconds. The loop exits when all
+  pending containers have been processed or the 300-second timeout is reached; timed-out
+  containers are skipped with a log message.
+
+Log files for the first pass use a double-underscore separator (`pod__container.log`).
+Log files collected in the retry loop use a single-underscore separator (`pod_container.log`).
+
+### Monitoring YAML files
+
+When `monitoring_pipeline: true`, the following files are written to `artifacts/`:
+
+| File | Resource |
+|---|---|
+| `vmalertmanagers.yaml` | `VMAlertManager` |
+| `vmalerts.yaml` | `VMAlert` |
+| `vmagent.yaml` | `VMAgent` |
+| `vmsingles.yaml` | `VMSingle` |
+| `vmauths.yaml` | `VMAuth` |
+| `PlatformMonitoring.yaml` | `PlatformMonitoring platformmonitoring` |
+
+All commands use `|| true` — missing CRDs do not fail the step.
+
+---
+
+## Usage
+
+```yaml
+name: Collect Diagnostics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diagnostics:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
+        with:
+          path: qubership-test-pipelines
+
+      - name: Collect diagnostics
+        if: always()
+        uses: Netcracker/qubership-test-pipelines/actions/shared/collect_diag_info@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+        with:
+          namespace: consul
+          service_branch: ${{ github.ref_name }}
+```
+
+---
+
+## Notes
+
+- All diagnostic steps run with `if: always()` — they collect data even when earlier steps
+  in the caller's job have failed. Call this action with `if: always()` as well to ensure
+  it runs after a failed Helm deploy or verification step.
+- The `artifacts/` directory is created but **not** cleared by this action. If a prior step
+  in the same job already populated `artifacts/`, those files will be included in the upload.
+- The `Get Secrets` step logs secret names to the workflow run log (not values). Anyone with
+  read access to the workflow run can see the secret names in the namespace.
+- The `version` input is used as a suffix in the auto-generated artifact name. Pass the
+  relevant matrix dimension (e.g. `${{ matrix.service_image }}`) explicitly — omit the input
+  to leave the suffix empty.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved —
+  acceptable only when callers explicitly want auto-updates within a minor version. Never
+  use `@main` or short SHAs.

--- a/actions/shared/collect_diag_info/README.md
+++ b/actions/shared/collect_diag_info/README.md
@@ -1,4 +1,4 @@
-# 🚀 Collect Diagnostics Action
+рк# 🚀 Collect Diagnostics Action
 
 GitHub Action to collect logs, resource manifests, and artifacts from a Kubernetes namespace
 and upload them as a workflow artifact for post-deploy or post-failure investigation.
@@ -22,7 +22,7 @@ and upload them as a workflow artifact for post-deploy or post-failure investiga
 ## 📌 Inputs
 
 | Name | Description | Required | Default |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `namespace` | Kubernetes namespace to collect diagnostics from. | Yes | - |
 | `service_branch` | Branch or tag name of the service being tested. Used in the auto-generated artifact name — slashes are replaced with underscores, whitespace is stripped. Ignored when `artifact_name` is provided. | No | - |
 | `artifact_name` | Custom base name for the uploaded artifact. When provided, the final name is `<artifact_name>_<timestamp>`. When empty, the name is generated as `<job>_<namespace>_<branch>_<version>_artifacts_<timestamp>`. | No | `""` |
@@ -107,7 +107,7 @@ Log files collected in the retry loop use a single-underscore separator (`pod_co
 When `monitoring_pipeline: true`, the following files are written to `artifacts/`:
 
 | File | Resource |
-|---|---|
+| --- | --- |
 | `vmalertmanagers.yaml` | `VMAlertManager` |
 | `vmalerts.yaml` | `VMAlert` |
 | `vmagent.yaml` | `VMAgent` |

--- a/actions/shared/collect_diag_info/README.md
+++ b/actions/shared/collect_diag_info/README.md
@@ -1,4 +1,4 @@
-рк# 🚀 Collect Diagnostics Action
+# 🚀 Collect Diagnostics Action
 
 GitHub Action to collect logs, resource manifests, and artifacts from a Kubernetes namespace
 and upload them as a workflow artifact for post-deploy or post-failure investigation.

--- a/actions/shared/collect_diag_info/action.yml
+++ b/actions/shared/collect_diag_info/action.yml
@@ -17,6 +17,13 @@ inputs:
     required: false
     default: ""
 
+  version:
+    description: |
+      Matrix version value used as a suffix in the auto-generated artifact name.
+      Pass any matrix dimension that identifies this run (e.g. matrix.version or matrix.service_image).
+    required: false
+    default: ""
+
   monitoring_pipeline:
     description: |
       Only for Monitoring. Enable monitoring CRs checks (true) or disable them (false)
@@ -33,7 +40,7 @@ runs:
       run: mkdir -p artifacts
 
     - name: Get monitoring specific resources
-      if: ${{ inputs.monitoring_pipeline == 'true' }}
+      if: always() && inputs.monitoring_pipeline == 'true'
       shell: bash
       env:
         NAMESPACE: ${{ inputs.namespace }}
@@ -236,7 +243,7 @@ runs:
       env:
         SERVICE_BRANCH: ${{ inputs.service_branch }}
         INPUT_ARTIFACT_NAME: ${{ inputs.artifact_name }}
-        MATRIX_VERSION: ${{ matrix.version }}
+        MATRIX_VERSION: ${{ inputs.version }}
         GITHUB_JOB: ${{ github.job }}
         NAMESPACE: ${{ inputs.namespace }}
       run: |

--- a/actions/shared/create_ingress/README.md
+++ b/actions/shared/create_ingress/README.md
@@ -1,0 +1,134 @@
+# 🚀 Create Ingress-Controller
+
+GitHub Action that installs ingress-nginx into a `kind` cluster and configures CoreDNS
+with a wildcard `*.testdomain.local` DNS zone pointing to the ingress controller's ClusterIP.
+
+---
+
+## Features
+
+- Deploys the official `ingress-nginx` controller for `kind` clusters
+- Patches the `nginx` IngressClass to be the cluster-wide default
+- Configures CoreDNS to resolve all `*.testdomain.local` hostnames to the nginx ClusterIP,
+  enabling in-cluster DNS-based routing without external DNS
+- Restarts CoreDNS pods and waits up to 180 seconds for them to become ready
+- Prints pod and event status for the `ingress-nginx` namespace after setup
+
+---
+
+## 📌 Inputs
+
+This action has no inputs.
+
+---
+
+## 📌 Outputs
+
+This action produces no outputs.
+
+---
+
+## How it works
+
+The action performs four cluster-level changes, all of which are permanent for the lifetime
+of the `kind` cluster:
+
+1. **Install ingress-nginx**: applies the official `kind` ingress manifest from
+   `https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml` and patches the
+   `nginx` IngressClass to be the default class. Any Ingress resource without an explicit
+   `ingressClassName` will be handled by this controller.
+2. **Configure wildcard DNS**: reads the ClusterIP of the `ingress-nginx-controller` service
+   in the `ingress-nginx` namespace, then replaces the `kube-system/coredns` ConfigMap with
+   an updated Corefile. The new Corefile adds a `testdomain.local:53` zone that answers any
+   query matching `*.testdomain.local` with the nginx ClusterIP:
+
+   ```text
+   testdomain.local:53 {
+       template ANY ANY  {
+           match .*\.testdomain\.local\.$
+           answer "{{ .Name }} 60 IN A <nginx-clusterip>"
+           fallthrough
+       }
+   }
+   ```
+
+3. **Restart CoreDNS**: deletes all pods with label `k8s-app=kube-dns` in `kube-system` to
+   force a reload of the new ConfigMap. Kubernetes recreates them automatically.
+4. **Wait for readiness**: runs `kubectl wait --for=condition=Ready` on the new CoreDNS pods
+   with a 180-second timeout. The action fails if pods do not become ready in time.
+
+After setup, any workload in the cluster can reach the ingress controller by pointing an
+Ingress resource to a `*.testdomain.local` hostname — no external DNS configuration is needed.
+
+---
+
+## Additional Information
+
+### testdomain.local DNS zone
+
+The wildcard zone is cluster-internal only. `*.testdomain.local` hostnames resolve to the
+nginx ClusterIP, which is not routable outside the cluster. This is designed for in-cluster
+test scenarios where services communicate via Ingress resources using fixed hostnames.
+
+The CoreDNS ConfigMap is replaced (not patched) using `kubectl replace`. The full Corefile,
+including the original `cluster.local` zone configuration, is embedded in the action and
+printed to the workflow log during the replace step.
+
+### kind cluster requirement
+
+The ingress manifest is sourced directly from `https://kind.sigs.k8s.io/examples/ingress/deploy-ingress-nginx.yaml`.
+This action is designed exclusively for `kind` clusters and will not work correctly on other
+cluster types without modification.
+
+### No waiting for ingress-nginx readiness
+
+The action does not wait for the `ingress-nginx-controller` deployment to become ready before
+reading its ClusterIP. The ClusterIP is assigned at Service creation time and is available
+immediately after `kubectl apply`, but the controller pods themselves may still be starting.
+If subsequent steps depend on the controller being fully functional, add a `kubectl wait`
+step after this action.
+
+---
+
+## Usage
+
+```yaml
+name: Setup Kind Ingress
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
+        with:
+          path: qubership-test-pipelines
+
+      - name: Create ingress controller
+        uses: Netcracker/qubership-test-pipelines/actions/shared/create_ingress@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+```
+
+---
+
+## Notes
+
+- This action modifies the `kube-system/coredns` ConfigMap using `kubectl replace` — it
+  overwrites any previous custom CoreDNS configuration. Run it before any step that adds
+  additional CoreDNS rules.
+- The full Corefile content (including the nginx ClusterIP) is printed to the workflow log
+  during the CoreDNS patch step.
+- Designed for `kind` clusters only. The ingress manifest URL is pinned to the official
+  `kind.sigs.k8s.io` example and may not suit production or other cluster types.
+- If CoreDNS pods do not reach `Ready` within 180 seconds, the action fails and subsequent
+  steps will not run. Check `kubectl get pods -n kube-system` and `kubectl describe` output
+  in the workflow log for the root cause.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved —
+  acceptable only when callers explicitly want auto-updates within a minor version. Never
+  use `@main` or short SHAs.

--- a/actions/shared/create_restricted_resources/README.md
+++ b/actions/shared/create_restricted_resources/README.md
@@ -21,7 +21,7 @@ so that subsequent Helm commands run under that user's permissions.
 ## 📌 Inputs
 
 | Name | Description | Required | Default |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `service_name` | Helm release name. Also used as the subdirectory name under `qubership-test-pipelines/restricted/` when looking for service-specific ClusterRoles and ClusterRoleBindings. | Yes | - |
 | `repository_name` | Service repository name. Accepted for call-site compatibility with `helm_deploy` but not used by any step in this action. | No | - |
 | `path_to_chart` | Path to the Helm chart within the service repository. Accepted for call-site compatibility with `helm_deploy` but not used by any step in this action. | No | - |

--- a/actions/shared/create_restricted_resources/README.md
+++ b/actions/shared/create_restricted_resources/README.md
@@ -1,22 +1,127 @@
 # 🚀 Create Restricted Resources Action
-This Action creates resources before restricted installation
+
+GitHub Action to create RBAC resources and a client certificate for a restricted Helm
+installation. Sets up a `restricted` user in kubeconfig and switches to a `restricted-context`
+so that subsequent Helm commands run under that user's permissions.
+
+---
 
 ## Features
-- Creates ClusterRoles, ClusterRoleBindings and CRDs
-- Generates client certificates for restricted access
-- Creates restricted Role and RoleBinding
-- Creates Kubernetes context for restricted user
+
+- Optionally creates service-specific ClusterRoles and ClusterRoleBindings from files in
+  `qubership-test-pipelines/restricted/<service_name>/` (skips with a warning if absent)
+- Generates a 2048-bit RSA client key and certificate via the Kubernetes CSR API
+- Creates a namespace-scoped `Role` and `RoleBinding` granting the `restricted` user full
+  access within the target namespace
+- Registers the `restricted` user credentials in the current kubeconfig
+- Creates and activates a `restricted-context` pointing to `kind-kind` and the target namespace
+
+---
 
 ## 📌 Inputs
 
-| Name              | Required | Description                                           |
-|-------------------|----------|-------------------------------------------------------|
-| `service_name`    | Yes      | Helm release name                                     |
-| `repository_name` | Yes      | Service repository name (without organization prefix) |
-| `path_to_chart`   | Yes      | Path to Helm chart in service repository              |
-| `namespace`       | Yes      | Target Kubernetes namespace                           |
+| Name | Description | Required | Default |
+|---|---|---|---|
+| `service_name` | Helm release name. Also used as the subdirectory name under `qubership-test-pipelines/restricted/` when looking for service-specific ClusterRoles and ClusterRoleBindings. | Yes | - |
+| `repository_name` | Service repository name. Accepted for call-site compatibility with `helm_deploy` but not used by any step in this action. | No | - |
+| `path_to_chart` | Path to the Helm chart within the service repository. Accepted for call-site compatibility with `helm_deploy` but not used by any step in this action. | No | - |
+| `namespace` | Kubernetes namespace for the installation. Used as the `metadata.namespace` in the `Role` and `RoleBinding` and as the default namespace in the kubeconfig context. | Yes | - |
 
-## Usage Example
+---
+
+## 📌 Outputs
+
+This action produces no step outputs. Its side-effects are the RBAC objects created in the
+cluster and the kubeconfig context switch to `restricted-context`.
+
+---
+
+## How it works
+
+The action sets up a restricted user identity for a Helm install in four phases:
+
+**Phase 1 — Service-specific cluster RBAC (optional):**
+Looks for `qubership-test-pipelines/restricted/<service_name>/clusterRoles/` and
+`clusterRoleBindings/` directories. If either is present, every file in it is applied with
+`kubectl create`. If either directory is missing, a warning annotation is emitted and the
+phase is skipped — the action does not fail.
+
+**Phase 2 — Client certificate:**
+Generates a 2048-bit RSA private key (`restricted.key`) and a CSR with subject
+`CN=restricted/O=dev-team`. Any pre-existing `restricted-csr` CertificateSigningRequest
+object is deleted first. A new CSR object (`kubernetes.io/kube-apiserver-client` signer,
+`client auth` usage) is submitted, approved, and the signed certificate is retrieved as
+`restricted.crt`.
+
+**Phase 3 — Namespace Role and RoleBinding:**
+Patches `qubership-test-pipelines/restricted/restricted-role.yml` and
+`qubership-test-pipelines/restricted/restricted-rb.yml` in-place, setting
+`metadata.namespace` to `inputs.namespace` using `scripts/update_yaml.py`. Then applies both
+files. The Role grants `["*"]` verbs on `["*"]` resources within the namespace; the
+RoleBinding binds the `restricted` User to that Role.
+
+**Phase 4 — kubeconfig setup:**
+Registers the `restricted` credentials (certificate + key) in kubeconfig, creates
+`restricted-context` targeting the `kind-kind` cluster and the target namespace, and switches
+the active context to `restricted-context`. All subsequent `kubectl` and `helm` calls in the
+job run as the `restricted` user until the context is changed again.
+
+---
+
+## Additional Information
+
+### Service-specific ClusterRole directory layout
+
+Place service-specific cluster-scoped resources under:
+
+```text
+qubership-test-pipelines/
+  restricted/
+    <service_name>/
+      clusterRoles/
+        my-clusterrole.yaml
+      clusterRoleBindings/
+        my-clusterrolebinding.yaml
+```
+
+Both subdirectories are optional. If neither exists (no entry for the service at all),
+both phases emit a warning and continue. Existing services with files:
+
+- `consul` — 2 ClusterRoleBindings, 2 ClusterRoles
+- `opensearch` — 2 ClusterRoleBindings, 3 ClusterRoles
+- `rabbitmq` — 1 ClusterRoleBinding
+
+### Role permissions
+
+The `restricted-role.yml` template grants the following within the target namespace:
+
+```yaml
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+```
+
+This is full namespace admin access, not a narrowly scoped restricted role. The name
+`restricted` refers to the authentication identity (certificate-based user), not to
+limited permissions.
+
+### update_yaml.py
+
+`scripts/update_yaml.py` modifies YAML files on disk using a slash-delimited path
+(`metadata/namespace`). It overwrites the file in-place and re-serialises it with PyYAML,
+which may alter key ordering and comment stripping. The `restricted-role.yml` and
+`restricted-rb.yml` files are modified every time this action runs.
+
+### Context switch
+
+After this action completes, the active kubeconfig context is `restricted-context`. The
+caller (`helm_deploy`) must switch back to `kind-kind` after the Helm call. The `helm_deploy`
+action does this with `kubectl config use-context kind-kind` when `restricted: true`.
+
+---
+
+## Usage
 
 ```yaml
 name: Create Restricted Resources
@@ -26,13 +131,37 @@ on:
 
 jobs:
   restricted-install:
-    runs-on: ${{inputs.runner_type}}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Create restricted resources
-        uses: Netcracker/qubership-test-pipelines/actions/shared/create_restricted_resources@main
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
         with:
-          service_name: 'consul'
-          repository_name: 'qubership-consul'
-          path_to_chart: 'charts/helm/consul-service'
-          namespace: 'consul'
+          path: qubership-test-pipelines
+
+      - name: Create restricted resources
+        uses: Netcracker/qubership-test-pipelines/actions/shared/create_restricted_resources@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+        with:
+          service_name: consul
+          repository_name: Netcracker/qubership-consul
+          path_to_chart: charts/helm/consul-service
+          namespace: consul
 ```
+
+---
+
+## Notes
+
+- The CSR YAML submitted to Kubernetes contains the base64-encoded CSR (derived from
+  `restricted.key`) and is printed to the log as part of `kubectl apply` output.
+- The `restricted-role.yml` and `restricted-rb.yml` files are modified on disk. If the same
+  runner reuses the workspace across jobs without a clean checkout, the namespace value from
+  a previous run may persist.
+- This action is designed for `kind` clusters. The kubeconfig context is hardcoded to
+  `kind-kind` as the cluster name.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved —
+  acceptable only when callers explicitly want auto-updates within a minor version. Never
+  use `@main` or short SHAs.

--- a/actions/shared/create_restricted_resources/action.yml
+++ b/actions/shared/create_restricted_resources/action.yml
@@ -29,28 +29,32 @@ runs:
     # Create CRD
     - name: Create ClusterRoles
       shell: bash
+      env:
+        SERVICE_NAME: ${{ inputs.service_name }}
       # language=bash
       run: |
         # ▶️ Create ClusterRoles
-        restricted_folder="qubership-test-pipelines/restricted/${{inputs.service_name}}"
+        restricted_folder="qubership-test-pipelines/restricted/${SERVICE_NAME}"
         if [ ! -d "$restricted_folder" ] || [ ! -d "$restricted_folder/clusterRoles" ]; then
           echo "::warning::Files with clusterRoles not found. Resources not created."
         else
           echo "Applying ClusterRoles..."
-          kubectl create -f $restricted_folder/clusterRoles
+          kubectl create -f "$restricted_folder/clusterRoles"
         fi
 
     - name: Create ClusterRoleBindings
       shell: bash
+      env:
+        SERVICE_NAME: ${{ inputs.service_name }}
       # language=bash
       run: |
         # ▶️ Create ClusterRoleBindings
-        restricted_folder="qubership-test-pipelines/restricted/${{inputs.service_name}}"
+        restricted_folder="qubership-test-pipelines/restricted/${SERVICE_NAME}"
         if [ ! -d "$restricted_folder" ] || [ ! -d "$restricted_folder/clusterRoleBindings" ]; then
           echo "::warning::Files with clusterRoleBindings not found. Resources not created."
         else
           echo "Applying clusterRoleBindings..."
-          kubectl create -f $restricted_folder/clusterRoleBindings
+          kubectl create -f "$restricted_folder/clusterRoleBindings"
         fi
 
 # Create Certificate
@@ -103,23 +107,27 @@ runs:
 # Create Role and RB
     - name: Update yaml with Role
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
         # ▶️ Update yaml with Role
         python qubership-test-pipelines/scripts/update_yaml.py \
           --file='qubership-test-pipelines/restricted/restricted-role.yml' \
           --path='metadata/namespace' \
-          --value='${{inputs.namespace}}'
+          --value="${NAMESPACE}"
 
     - name: Update yaml with RoleBinding
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
         # ▶️ Update yaml with RoleBinding
         python qubership-test-pipelines/scripts/update_yaml.py \
           --file='qubership-test-pipelines/restricted/restricted-rb.yml' \
           --path='metadata/namespace' \
-          --value='${{inputs.namespace}}'
+          --value="${NAMESPACE}"
 
     - name: Create Role
       shell: bash
@@ -139,8 +147,10 @@ runs:
 
     - name: Create context for user
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
-      run: kubectl config set-context restricted-context --cluster=kind-kind --namespace=${{inputs.namespace}} --user=restricted
+      run: kubectl config set-context restricted-context --cluster=kind-kind --namespace="${NAMESPACE}" --user=restricted
 
     - name: Use context
       shell: bash

--- a/actions/shared/create_restricted_resources/action.yml
+++ b/actions/shared/create_restricted_resources/action.yml
@@ -10,13 +10,13 @@ inputs:
     description: |
       Service repository name (without organization prefix)
       Example: 'qubership-consul' for https://github.com/Netcracker/qubership-consul
-    required: true
+    required: false
 
   path_to_chart:
     description: |
       Path to helm chart within service repository
       Example: 'charts/helm/consul-service'
-    required: true
+    required: false
 
   namespace:
     description: |
@@ -150,4 +150,4 @@ runs:
     - name: Get config
       shell: bash
       # language=bash
-      run: kubectl config view --raw
+      run: kubectl config view

--- a/actions/shared/get_certs/README.md
+++ b/actions/shared/get_certs/README.md
@@ -18,7 +18,7 @@ the base64-encoded values to files in the runner's temporary directory.
 ## 📌 Inputs
 
 | Name | Description | Required | Default |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `service_name` | Helm release name. Accepted for call-site compatibility but not used by any step in this action. | No | - |
 | `secret_name` | Name of the Kubernetes secret containing the TLS certificates. Also used as the prefix for the output file names. | Yes | - |
 | `namespace` | Kubernetes namespace where the secret is located. | Yes | - |
@@ -40,7 +40,7 @@ an error. On success, the three base64-encoded values are written to files under
 `${{ runner.temp }}`:
 
 | File | Content |
-|---|---|
+| --- | --- |
 | `${{ runner.temp }}/<secret_name>_ca_crt.txt` | `data["ca.crt"]` — base64-encoded CA certificate |
 | `${{ runner.temp }}/<secret_name>_tls_crt.txt` | `data["tls.crt"]` — base64-encoded server certificate |
 | `${{ runner.temp }}/<secret_name>_tls_key.txt` | `data["tls.key"]` — base64-encoded private key |

--- a/actions/shared/get_certs/README.md
+++ b/actions/shared/get_certs/README.md
@@ -1,0 +1,151 @@
+# 🚀 Get Certs Action
+
+GitHub Action to extract TLS certificate data from a Kubernetes secret and write
+the base64-encoded values to files in the runner's temporary directory.
+
+---
+
+## Features
+
+- Reads a named Kubernetes TLS secret from the specified namespace
+- Extracts `ca.crt`, `tls.crt`, and `tls.key` fields from the secret's `data` block
+- Fails immediately if any of the three fields is absent or empty
+- Writes each base64-encoded value to a separate file in `${{ runner.temp }}`
+  for consumption by subsequent steps
+
+---
+
+## 📌 Inputs
+
+| Name | Description | Required | Default |
+|---|---|---|---|
+| `service_name` | Helm release name. Accepted for call-site compatibility but not used by any step in this action. | No | - |
+| `secret_name` | Name of the Kubernetes secret containing the TLS certificates. Also used as the prefix for the output file names. | Yes | - |
+| `namespace` | Kubernetes namespace where the secret is located. | Yes | - |
+
+---
+
+## 📌 Outputs
+
+This action produces no step outputs. Certificate data is written to files in
+`${{ runner.temp }}` (see Additional Information for file paths and format).
+
+---
+
+## How it works
+
+The action installs `yq` via `snap`, then reads the named Kubernetes secret from the cluster
+and extracts three certificate fields. If any field is missing or empty the action exits with
+an error. On success, the three base64-encoded values are written to files under
+`${{ runner.temp }}`:
+
+| File | Content |
+|---|---|
+| `${{ runner.temp }}/<secret_name>_ca_crt.txt` | `data["ca.crt"]` — base64-encoded CA certificate |
+| `${{ runner.temp }}/<secret_name>_tls_crt.txt` | `data["tls.crt"]` — base64-encoded server certificate |
+| `${{ runner.temp }}/<secret_name>_tls_key.txt` | `data["tls.key"]` — base64-encoded private key |
+
+Subsequent steps in the same job can read these files directly. The `runner.temp` directory
+is not uploaded as a workflow artifact and is cleaned up at the end of the job.
+
+---
+
+## Additional Information
+
+### Output file format
+
+The values written to disk are the **base64-encoded** strings exactly as they appear in the
+Kubernetes secret's `data` block — not the raw PEM content. Callers that need the decoded
+PEM must base64-decode the file content:
+
+```bash
+base64 --decode < "${{ runner.temp }}/<secret_name>_ca_crt.txt" > ca.crt
+base64 --decode < "${{ runner.temp }}/<secret_name>_tls_crt.txt" > tls.crt
+base64 --decode < "${{ runner.temp }}/<secret_name>_tls_key.txt" > tls.key
+```
+
+### Expected secret structure
+
+The action expects a standard Kubernetes TLS secret with the following `data` keys:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: <secret_name>
+  namespace: <namespace>
+data:
+  ca.crt: <base64>
+  tls.crt: <base64>
+  tls.key: <base64>
+```
+
+If any of `ca.crt`, `tls.crt`, or `tls.key` is absent or empty, the action exits with
+`exit 1` and a `ERROR: Failed to extract certificates!` message.
+
+### yq installation
+
+The action installs `yq` via `sudo snap install yq` on every run. This requires:
+
+- The runner to support `snap` (standard on Ubuntu GitHub-hosted runners)
+- Network access to the snap store
+- Approximately 10–30 seconds of additional setup time per run
+
+There is no version pin on the `snap install` command — the latest available `yq` snap is
+always installed.
+
+---
+
+## Usage
+
+```yaml
+name: Get TLS Certificates
+
+on:
+  workflow_dispatch:
+
+jobs:
+  get-certs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
+        with:
+          path: qubership-test-pipelines
+
+      - name: Get TLS certificates from secret
+        uses: Netcracker/qubership-test-pipelines/actions/shared/get_certs@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+        with:
+          service_name: consul
+          secret_name: consul-tls
+          namespace: consul
+
+      - name: Use certificate
+        shell: bash
+        run: |
+          base64 --decode < "${{ runner.temp }}/consul-tls_ca_crt.txt" > ca.crt
+          echo "CA certificate extracted."
+```
+
+---
+
+## Notes
+
+- The full Kubernetes secret YAML (all fields, all data keys) is fetched into a shell
+  variable during extraction. The raw secret content passes through the step's shell
+  environment but is not echoed to the log by this action.
+- Output files contain base64-encoded data, not decoded PEM. Decode with
+  `base64 --decode` before passing to tools that expect PEM format.
+- Files in `${{ runner.temp }}` persist for the lifetime of the job but are not automatically
+  uploaded as workflow artifacts. If certificate data is needed across jobs, upload it
+  explicitly (with care given the sensitivity of private key material).
+- The `tls.key` file contains the base64-encoded private key. Treat the runner's temp
+  directory as sensitive storage and avoid logging its contents.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved —
+  acceptable only when callers explicitly want auto-updates within a minor version. Never
+  use `@main` or short SHAs.

--- a/actions/shared/get_certs/action.yml
+++ b/actions/shared/get_certs/action.yml
@@ -19,11 +19,15 @@ runs:
   steps:
     - name: Get secrets
       shell: bash
+      env:
+        SECRET_NAME: ${{ inputs.secret_name }}
+        NAMESPACE: ${{ inputs.namespace }}
+        RUNNER_TEMP: ${{ runner.temp }}
       # language=bash
       run: |
         # ▶️ Get secrets
         sudo snap install yq
-        secret=$(kubectl get secret ${{inputs.secret_name}} -oyaml -n ${{inputs.namespace}})
+        secret=$(kubectl get secret "${SECRET_NAME}" -oyaml -n "${NAMESPACE}")
         ca_crt=$(echo "$secret" | yq eval '.data["ca.crt"]' -)
         tls_crt=$(echo "$secret" | yq eval '.data["tls.crt"]' -)
         tls_key=$(echo "$secret" | yq eval '.data["tls.key"]' -)
@@ -33,6 +37,6 @@ runs:
           exit 1
         fi
 
-        echo "$ca_crt" > ${{runner.temp}}/${{inputs.secret_name}}_ca_crt.txt
-        echo "$tls_crt" > ${{runner.temp}}/${{inputs.secret_name}}_tls_crt.txt
-        echo "$tls_key" > ${{runner.temp}}/${{inputs.secret_name}}_tls_key.txt
+        echo "$ca_crt" > "${RUNNER_TEMP}/${SECRET_NAME}_ca_crt.txt"
+        echo "$tls_crt" > "${RUNNER_TEMP}/${SECRET_NAME}_tls_crt.txt"
+        echo "$tls_key" > "${RUNNER_TEMP}/${SECRET_NAME}_tls_key.txt"

--- a/actions/shared/get_certs/action.yml
+++ b/actions/shared/get_certs/action.yml
@@ -4,7 +4,7 @@ inputs:
   service_name:
     description: |
       Helm release name
-    required: true
+    required: false
   secret_name:
     description: |
       Name of secret with certs

--- a/actions/shared/get_crds/action.yaml
+++ b/actions/shared/get_crds/action.yaml
@@ -19,9 +19,11 @@ runs:
     - name: Get CRDs
       id: get_crds
       shell: bash
+      env:
+        CRD_LOCATION: ${{ inputs.crd_location }}
       run: |
         # ▶️ Get CRDs
-        yamls=$(find ${{inputs.crd_location}} -type f -name "*.yaml" -or -name "*.yml")
+        yamls=$(find "${CRD_LOCATION}" -type f -name "*.yaml" -or -name "*.yml")
         CRDS_ARRAY=()
         for yaml in ${yamls}; do
           yml_kind=$(yq e '.kind' $yaml)

--- a/actions/shared/get_crds/action.yaml
+++ b/actions/shared/get_crds/action.yaml
@@ -1,4 +1,5 @@
 name: Get CRD names
+description: GitHub Action to get CRD names from yaml files
 inputs:
   crd_location:
     description: |
@@ -8,6 +9,7 @@ inputs:
       # if checked out to qubership-kafka directory, then
       # 'qubership-kafka/operator/charts/helm/kafka-service/crds'
     required: true
+    type: string
 outputs:
   crd_names:
     value: ${{ steps.get_crds.outputs.crd_names }}

--- a/actions/shared/helm_deploy/README.md
+++ b/actions/shared/helm_deploy/README.md
@@ -1,50 +1,163 @@
-# 🚀 Helm Deploy GitHub Action
-This Action automates Helm install/upgrade services using Helm
+# 🚀 Helm Deploy Action
+
+GitHub Action to install or upgrade Kubernetes services using Helm.
+
+---
+
 ## Features
-- Checkout service and pipeline repositories
-- Namespace creation for new installations
-- Creation necessary resources before restricted installation
-- Replace Docker image versions in Helm charts for specified components
-- Deploy service with specified templates
-- Deploy (install/upgrade) service using Helm
-- Deploy with restricted permissions or cluster-admin rights
+
+- Checks out the target service repository at the specified branch or commit
+- Creates the target namespace when deploying in `install` mode
+- Applies pre-installation Kubernetes resources from a configurable folder
+- Creates or replaces CRDs found in the chart's `crds/` directory
+- Sets up restricted RBAC resources (ServiceAccount, ClusterRoleBinding) when running in restricted mode
+- Patches `values.yaml` to override a specific Docker image tag (`image_replacement`)
+- Updates the `tags` field in the values template for test filtering (`test_tags`)
+- Runs `charts-values-update-action` to propagate the service branch or commit tag into chart values
+  (skipped when `service_branch` is a release version)
+- Installs or upgrades the Helm release with a configurable values template
+- Logs all running pod images after deploy
+- Restores the default kubeconfig context after restricted-mode deploys
+
+---
 
 ## 📌 Inputs
 
-| Name               | Required | Default   | Type    | Description                                                                |
-|--------------------|----------|-----------|---------|----------------------------------------------------------------------------|
-| `deploy_mode`      | Yes      | `install` | string  | Deployment mode: 'install'/'update'                                        |
-| `restricted`       | Yes      | `false`   | boolean | Use restricted mode or not (installation by user with restricted rights)   |
-| `path_to_template` | Yes      | -         | string  | Path to template file in qubership-test-pipelines repository               |
-| `service_branch`   | Yes      | -         | string  | Branch in service repository                                               |
-| `service_name`     | Yes      | -         | string  | Helm release name                                                          |
-| `repository_name`  | Yes      | -         | string  | Service repository name (without organization prefix)                      |
-| `path_to_chart`    | Yes      | -         | string  | Path to Helm chart in service repository                                   |
-| `components`       | Yes      | -         | string  | List of components for image updates                                       |
-| `namespace`        | Yes      | -         | string  | Kubernetes target namespace                                                |
+| Name | Description | Required | Default |
+|---|---|---|---|
+| `deploy_mode` | Deployment mode: `install` for a clean installation, `upgrade` to upgrade an existing release. | Yes | `install` |
+| `restricted` | When `true`, installs using a user with restricted rights and passes `--skip-crds` to Helm. When `false`, installs as cluster admin. | Yes | `false` |
+| `path_to_template` | Path to the values template file inside the `qubership-test-pipelines` repository. Example: `templates/consul-service/consul_clean_infra_passport.yml` | Yes | - |
+| `service_branch` | Branch, tag, or commit SHA in the service repository to check out. A value matching `vX.Y.Z` is treated as a release and skips chart-values update. | Yes | - |
+| `service_name` | Helm release name used in `helm install`/`upgrade`. | Yes | - |
+| `repository_name` | Full `org/repo` name of the service repository. Example: `Netcracker/qubership-consul` | Yes | - |
+| `path_to_chart` | Path to the Helm chart directory within the service repository. Example: `charts/helm/consul-service` | Yes | - |
+| `namespace` | Kubernetes namespace for the installation. Created automatically in `install` mode. | Yes | - |
+| `resource_folder` | Path (relative to repo root) to a folder of Kubernetes manifests applied with `kubectl create` before installation. Pass an empty string to skip. | Yes | - |
+| `image_replacement` | Full image name including tag to pin in `values.yaml`, e.g. `pgskipper-docker-patroni-18`. The base name (everything before the last `-`) is used to locate the existing value. Skipped when empty. | No | `""` |
+| `test_tags` | Replacement value for the `tags:` field in the values template. Skipped when empty. | Yes | `""` |
 
-## Usage Example
+---
+
+## 📌 Outputs
+
+This action produces no outputs.
+
+---
+
+## How it works
+
+1. The service repository is checked out into a subdirectory named after `repository_name`.
+2. In `install` mode the target namespace is created if it does not already exist.
+3. If `resource_folder` is non-empty, every file in that folder is applied with `kubectl create`.
+4. The chart's `crds/` directory is walked and each CRD is created or replaced via `kubectl`.
+5. When `restricted: true` and `deploy_mode: install`, the
+   `actions/shared/create_restricted_resources` local action runs to set up RBAC objects.
+6. The values template is copied from `qubership-test-pipelines` into the chart directory.
+7. `service_branch` is classified as a release (`vX.Y.Z`) or non-release. For non-release branches
+   and commits, `charts-values-update-action` rewrites image tags in chart values to match the
+   branch name or a normalised commit hash (`git-<7chars>`). For release branches this step is
+   skipped entirely.
+8. If `image_replacement` is set, the matching image tag in `values.yaml` is replaced with the
+   provided value using `sed`.
+9. If `test_tags` is set, the `tags:` line in the copied template file is replaced.
+10. `helm install` or `helm upgrade` runs against the chart directory, using the copied template as
+    `-f <template>`. Restricted mode adds `--skip-crds`. Timeout is always 10 minutes.
+11. Pod images in the namespace are printed with `kubectl get pods`.
+12. When `restricted: true`, the kubeconfig context is restored to `kind-kind` after the deploy.
+13. `kubectl get all -n <namespace>` runs unconditionally (`if: always()`) to show post-deploy state.
+
+---
+
+## Additional Information
+
+### `service_branch` normalisation
+
+Before passing the branch or commit to `charts-values-update-action`, slashes are replaced with
+underscores. Commit SHAs (7–40 hex characters) are normalised to `git-<first7chars>`, e.g.
+`git-a1b2c3d`.
+
+### `restricted` mode
+
+When `restricted: true`:
+
+- The `create_restricted_resources` sub-action runs (install mode only), creating a dedicated
+  ServiceAccount and ClusterRoleBinding for the chart.
+- Helm is called with `--skip-crds` — CRDs are still managed separately in step 4 above.
+- After the Helm call, `kubectl config use-context kind-kind` restores the default context so
+  subsequent steps are not affected.
+
+### `image_replacement` matching
+
+The input must be the full image name including the version suffix, e.g.
+`pgskipper-docker-patroni-18`. The action strips the last `-<segment>` to derive the search
+pattern (`pgskipper-docker-patroni-`) and replaces the first occurrence in `values.yaml`. If the
+pattern is not found, the step fails with an error.
+
+### `resource_folder`
+
+The folder path is resolved relative to the `qubership-test-pipelines` checkout root. All files
+found recursively are applied with `kubectl create`. The input is required in the action signature;
+pass an empty string (`""`) to skip resource creation.
+
+### CRD management
+
+CRDs are always processed regardless of `deploy_mode`. The `crds/` directory must exist inside the
+chart path — its absence causes an error. Each CRD is applied with `kubectl replace` if it already
+exists, or `kubectl create` otherwise.
+
+---
+
+## Usage
 
 ```yaml
 name: Deploy Service with Helm
 
 on:
-  push
+  workflow_dispatch:
 
 jobs:
   helm-deploy:
-    runs-on: ${{inputs.runner_type}}
-    name: Run helm_deploy action
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Run helm_deploy action
-        uses: Netcracker/qubership-test-pipelines/actions/shared/helm_deploy@main
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
         with:
-          deploy_mode: 'install'
+          path: qubership-test-pipelines
+
+      - name: Run helm deploy
+        uses: Netcracker/qubership-test-pipelines/actions/shared/helm_deploy@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+        with:
+          deploy_mode: install
           restricted: false
-          path_to_template: 'templates/consul-service/consul_clean_infra_passport.yml'
-          service_branch: 'main'
-          service_name: 'consul'
-          repository_name: 'qubership-consul'
-          path_to_chart: 'charts/helm/consul-service'
-          namespace: 'consul'
+          path_to_template: templates/consul-service/consul_clean_infra_passport.yml
+          service_branch: main
+          service_name: consul
+          repository_name: Netcracker/qubership-consul
+          path_to_chart: charts/helm/consul-service
+          namespace: consul
+          resource_folder: ""
+          test_tags: ""
 ```
+
+---
+
+## Notes
+
+- `deploy_mode` accepts `install` or `upgrade` — not `update`.
+- The chart's `crds/` directory **must** exist; a missing directory causes an immediate failure.
+- `repository_name` must be the full `org/repo` form (e.g. `Netcracker/qubership-consul`), not
+  just the repo name. The checkout path and all subsequent paths are derived from this value.
+- `resource_folder` is declared `required: true` in the action signature — pass `""` when no
+  pre-installation resources are needed.
+- When `restricted: true`, both the CRD step and the Helm step run under separate contexts;
+  the context is always restored to `kind-kind` at the end.
+- For non-release branches, `charts-values-update-action` is pinned at commit
+  `d558e10a6537924292e7dd7ff4109c2bda9b406e` (v2.0.5) in the action source.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved — acceptable
+  only when callers explicitly want auto-updates within a minor version. Never use `@main` or
+  short SHAs.

--- a/actions/shared/helm_deploy/README.md
+++ b/actions/shared/helm_deploy/README.md
@@ -24,7 +24,7 @@ GitHub Action to install or upgrade Kubernetes services using Helm.
 ## 📌 Inputs
 
 | Name | Description | Required | Default |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `deploy_mode` | Deployment mode: `install` for a clean installation, `upgrade` to upgrade an existing release. | Yes | `install` |
 | `restricted` | When `true`, installs using a user with restricted rights and passes `--skip-crds` to Helm. When `false`, installs as cluster admin. | Yes | `false` |
 | `path_to_template` | Path to the values template file inside the `qubership-test-pipelines` repository. Example: `templates/consul-service/consul_clean_infra_passport.yml` | Yes | - |

--- a/actions/shared/verify_installation/README.md
+++ b/actions/shared/verify_installation/README.md
@@ -1,37 +1,210 @@
-# 🚀 Verify Installation GitHub Action
-This Action verifies Kubernetes deployments including status checks, log collection, and test validation.
+# 🚀 Verify Installation Action
+
+GitHub Action to verify Kubernetes deployments including Custom Resource status checks,
+pod readiness validation, and Robot Framework test result collection.
+
+---
 
 ## Features
-- Verifies pod readiness and final status
-- Gathers diagnostic data in structured format
-- Automatically checks Robot Framework test results
-- Configurable attempts with custom timeouts
-- Automatic exit on critical failures
+
+- Polls Custom Resource conditions (`failed` / `progress` / `success`) until ready or timed out
+- Validates readiness of all Deployments, StatefulSets, and DaemonSets in the namespace
+- Optionally verifies VictoriaMetrics Custom Resource statuses for monitoring pipelines
+- Detects and waits for a test pod (name contains `tests`) to complete
+- Collects Robot Framework HTML reports and output artifacts from the test pod
+- Saves test logs to `artifacts/<namespace>_tests.txt`
+- Aggregates all check results via a shared `ERROR_FLAG` and fails the step at the end
+  if any check did not pass
+
+---
 
 ## 📌 Inputs
 
-| Name                             | Description                  | Required | Default |
-|----------------------------------|------------------------------|----------|---------|
-| `namespace`                      | Target Kubernetes namespace  | Yes      | -       |
-| `test_completion_max_retries`    | Maximum verification retries | Yes      | 40      |
-| `test_completion_retry_interval` | Delay between attempts       | Yes      | 10s     |
+| Name | Description | Required | Default |
+|---|---|---|---|
+| `namespace` | Kubernetes namespace where the service is installed. | Yes | - |
+| `service_ready_max_retries` | Maximum number of poll attempts for CR and resource readiness checks. | Yes | - |
+| `service_ready_retry_interval` | Delay in seconds between CR and resource readiness poll attempts. | Yes | - |
+| `test_completion_max_retries` | Maximum number of poll attempts for the test pod to complete. Skipped when `check_tests` is `false`. | Yes | - |
+| `test_completion_retry_interval` | Delay in seconds between test pod completion poll attempts. Skipped when `check_tests` is `false`. | Yes | - |
+| `crd_list` | Space-separated list of Custom Resource names to check (e.g. `consul`). Pass empty to skip CR checks. | No | - |
+| `check_tests` | When `true`, waits for the test pod to complete and collects Robot Framework results. Set to `false` to skip test checks entirely. | No | `true` |
+| `monitoring_pipeline` | When `true`, runs additional VictoriaMetrics CR status checks using `check-vm-cr-statuses.sh`. Requires `repository_name` and the expected-vm-cr-statuses.json file to be present. | No | `false` |
+| `repository_name` | Full `org/repo` checkout path of the service repository. Required when `monitoring_pipeline` is `true` — used to locate `.github/expected-vm-cr-statuses.json`. | No | `""` |
 
-## Usage Example
+---
+
+## 📌 Outputs
+
+This action produces no step outputs. Results are communicated via exit code: the action
+exits with code `1` if any check failed, `0` on full success.
+
+---
+
+## How it works
+
+The action runs three sequential verification phases, collecting failures into a shared
+`ERROR_FLAG` environment variable, then fails or succeeds at the end:
+
+**Phase 1 — Service readiness** (always runs):
+
+- For each attempt up to `service_ready_max_retries`, `check_cr.sh` is called with the
+  `crd_list`. It inspects `.status.conditions` on the CR and classifies the result as
+  success (exit 0), in-progress (exit 1), or failed (exit 2). A failure exits the loop
+  and sets `ERROR_FLAG=true`; in-progress retries after `service_ready_retry_interval`
+  seconds.
+- After the CR loop, `check_resources.sh` polls readiness of all Deployments, StatefulSets,
+  and DaemonSets in the namespace. It checks `readyReplicas == replicas` for each resource.
+  Pods are printed on each not-ready attempt.
+
+**Phase 2 — Monitoring checks** (only when `monitoring_pipeline: true`):
+
+- The full service-readiness sequence from Phase 1 is repeated specifically for monitoring
+  resources.
+- `check-vm-cr-statuses.sh` reads `<repository_name>/.github/expected-vm-cr-statuses.json`,
+  filters components by what is enabled in the `PlatformMonitoring` CR, and checks each
+  VictoriaMetrics CR's status field or conditions. The JSON file is printed to the log
+  before the check (see Notes).
+
+**Phase 3 — Test validation** (only when `check_tests: true`):
+
+- `check_tests.sh` scans all pods in the namespace for one whose name contains `tests`.
+- Once found, it polls the pod phase and inspects logs for a `Report.*html` pattern that
+  signals Robot Framework has finished writing output.
+- On completion it copies `/opt/robot/output` and `/tmp/clone` from the pod into
+  `artifacts/robot-results/` and writes logs to `artifacts/<namespace>_tests.txt`.
+- Exit codes: `0` = passed, `1` = still running (retry), `2` = tests failed.
+- If no test pod is found, a warning is emitted and the phase is skipped.
+- After `test_completion_max_retries` attempts without completion, `ERROR_FLAG=true` is set.
+
+**Final step**: if `ERROR_FLAG` is `true`, the action exits with code `1`.
+
+---
+
+## Additional Information
+
+### CR condition classification
+
+`check_cr.sh` reads `.status.conditions[]` and classifies by matching condition `type`
+(case-insensitive substring):
+
+- Contains `failed` → exit 2 (hard failure, stops retrying)
+- Contains `progress` → exit 1 (still running, retry)
+- Contains `success` → exit 0 (done)
+- No matching condition → treated as in-progress (exit 1)
+
+If `crd_list` is empty, `check_cr.sh` returns exit 0 immediately and CR checking is skipped.
+
+### Resource readiness check
+
+`check_resources.sh` checks Deployments, StatefulSets, and DaemonSets:
+
+- Deployment / StatefulSet: `readyReplicas == replicas` and `replicas > 0`
+- DaemonSet: `numberReady == desiredNumberScheduled` and `desiredNumberScheduled > 0`
+
+A resource with zero replicas/desired is treated as not ready.
+
+### Test pod discovery
+
+The test pod is found by scanning all pod names in `namespace` for one containing the
+substring `tests`. Only the first matching pod is used. If the service deploys multiple
+pods with `tests` in their name, only the first one returned by kubectl is checked.
+
+### monitoring_pipeline expected-vm-cr-statuses.json
+
+The JSON file at `<repository_name>/.github/expected-vm-cr-statuses.json` defines which
+VictoriaMetrics components to check and what their expected state is. Its contents are
+printed to the workflow log before the check runs (see Notes for implications).
+
+Example file structure:
+
+```json
+[
+  {
+    "kind": "VMSingle",
+    "name": "victoria-metrics",
+    "component": "vmSingle",
+    "check": "updateStatus",
+    "jsonPath": ".status.updateStatus",
+    "expected": "operational"
+  },
+  {
+    "kind": "VMAgent",
+    "name": "vmagent-primary",
+    "component": "vmAgent",
+    "check": "conditionsMatch",
+    "expectedConditions": {
+      "reason": "Reconciled",
+      "status": "True"
+    }
+  }
+]
+```
+
+The script filters this list against the `install` flags in the `PlatformMonitoring` CR
+so only enabled components are checked.
+
+### Artifact folder
+
+An `artifacts/` directory is created (and cleared) at the start of every run. Robot
+Framework results are placed under `artifacts/robot-results/`. Test logs are written to
+`artifacts/<namespace>_tests.txt`. Upload this folder as a workflow artifact to preserve
+results between jobs.
+
+---
+
+## Usage
 
 ```yaml
-name: Verify Deployment
+name: Verify Service Installation
 
 on:
   workflow_dispatch:
 
 jobs:
-  verification:
-    runs-on: ${{inputs.runner_type}}
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Run Deployment Verification
-        uses: Netcracker/your-repo/actions/verify-installation@main
+      - name: Checkout pipeline repo
+        uses: actions/checkout@v4
         with:
-          namespace: 'consul'
-          test_completion_max_retries: 30
-          test_completion_retry_interval: '15s'
+          path: qubership-test-pipelines
+
+      - name: Verify installation
+        uses: Netcracker/qubership-test-pipelines/actions/shared/verify_installation@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0
+        with:
+          namespace: consul
+          service_ready_max_retries: 20
+          service_ready_retry_interval: 30
+          test_completion_max_retries: 40
+          test_completion_retry_interval: 15
+          crd_list: consul
+          check_tests: true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-results
+          path: artifacts/
 ```
+
+---
+
+## Notes
+
+- The `artifacts/` folder is wiped at action start — do not rely on content from previous
+  steps being present there.
+- The `monitoring_pipeline` step prints the full contents of `expected-vm-cr-statuses.json`
+  to the workflow log before checking. Avoid storing secrets or sensitive values in that file.
+- When `check_tests: true` but no pod with `tests` in its name exists, the step emits a
+  warning and exits cleanly (does not set `ERROR_FLAG`).
+- `service_ready_max_retries` and `test_completion_max_retries` have no defaults in
+  `action.yml` — callers must always provide explicit values.
+- Pin to a full 40-character commit SHA with the release tag as a trailing comment, e.g.
+  `@905b88900dc8c14291eaeff4eddcf4d4f734aee1 # v1.9.0`. The SHA is the immutable pin; the
+  comment shows which release it points to. Tags alone are mutable and can be moved —
+  acceptable only when callers explicitly want auto-updates within a minor version. Never
+  use `@main` or short SHAs.

--- a/actions/shared/verify_installation/README.md
+++ b/actions/shared/verify_installation/README.md
@@ -21,7 +21,7 @@ pod readiness validation, and Robot Framework test result collection.
 ## 📌 Inputs
 
 | Name | Description | Required | Default |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `namespace` | Kubernetes namespace where the service is installed. | Yes | - |
 | `service_ready_max_retries` | Maximum number of poll attempts for CR and resource readiness checks. | Yes | - |
 | `service_ready_retry_interval` | Delay in seconds between CR and resource readiness poll attempts. | Yes | - |

--- a/actions/shared/verify_installation/action.yml
+++ b/actions/shared/verify_installation/action.yml
@@ -66,11 +66,6 @@ runs:
       # language=bash
       run: echo "ERROR_FLAG=false" >> $GITHUB_ENV
 
-    - name: Initialize error flag
-      shell: bash
-      # language=bash
-      run: echo "ERROR_FLAG=false" >> $GITHUB_ENV
-
     - name: Check service is ready
       shell: bash
       env:


### PR DESCRIPTION
## What type of change is this? (check all applicable)

- [ ] Workflow change
- [ ] Workflow config / matrix change
- [ ] Deployment template / resource change
- [x] Action or script change
- [x] Documentation update
- [x] Bug fix
- [ ] Refactor / maintenance

## Description

Fix several correctness and security issues across six shared actions and add missing
READMEs for `collect_diag_info`, `create_ingress`, and `get_certs`. The fixes address
incorrectly declared `required: true` inputs that no
step actually uses, a duplicate `Initialize error flag` step in `verify_installation`,
a monitoring diagnostic step that could be skipped on job failure, and a hard-coded
`${{ matrix.version }}` context read in `collect_diag_info` that always resolved to
empty outside a matrix job.

## What is affected? (check all applicable)

- [ ] `.github/workflows/*`
- [ ] `workflow-config/*`
- [ ] `templates/*`
- [x] `actions/*`
- [ ] `scripts/*`
- [x] `docs/*`
- [ ] `resources/*` or `restricted/*`

## Services / scenarios impacted

- `repository_name` and  `path_to_chart` are now optional (callers with existing `with:` blocks are unaffected)
- `get_certs`: `service_name` is now optional — no caller behaviour change
- `verify_installation`: duplicate env-var initialisation step removed (was a no-op)
- `collect_diag_info`: monitoring diagnostic step now runs under `if: always()` so it
  collects data even when a preceding Helm deploy or verify step fails; `matrix.version`
  context access replaced with an explicit `version` input
- All six shared actions: new or significantly expanded READMEs added

## Related tickets and documents

- Related Issue #
- Related docs / workflow reference: `actions/shared/*/README.md`

## Verification

- [x] Static review only

All changes were verified by reading the action source and cross-checking against
callers in `.github/workflows/`. No pipeline run was possible on this documentation
branch. The `required: false` changes were confirmed
safe by grepping all callers — none would fail validation.

## Compatibility / impact

- [x] No compatibility impact
- [x] Workflow interface changed (`inputs`, `outputs`, `secrets`, job names)
- [ ] Template parameters or behavior changed
- [ ] Test matrix / covered scenarios changed
- [ ] Existing upgrade flow or previous behavior was checked
- [x] Documentation updated

`repository_name` and `path_to_chart` in `create_restricted_resources` and `service_name`
in `get_certs` changed from `required: true` to `required: false`. All existing callers
already pass these inputs explicitly, so no caller is broken. The change only relaxes
validation — previously callers that omitted these unused inputs would get an error.

## Additional notes (optional)

- The `collect_diag_info` action previously read `${{ matrix.version }}` directly from
  the job matrix context, which is not accessible inside a composite action — it always
  resolved to an empty string. The new `version` input is an explicit pass-through;
  all current callers already supply `artifact_name` so the artifact name is unaffected.
- The `verify_installation` action still contains a duplicated monitoring check block
  (Phase 2 logic appears in both `Check service is ready` and `Get monitoring specific
  resources` steps). This pre-existing duplication is documented in the README Notes
  section and is out of scope for this PR.