### PR TITLE
fix: change opensearch timeout

### DIFF
--- a/.github/workflows/opensearch.yaml
+++ b/.github/workflows/opensearch.yaml
@@ -138,7 +138,7 @@ jobs:
       namespace: opensearch
       test_completion_max_retries: 1
       test_completion_retry_interval: 10s
-      service_ready_max_retries: 140
+      service_ready_max_retries: 200
       service_ready_retry_interval: 10s
       service_branch: ""
       path_to_chart: operator/charts/helm/opensearch-service


### PR DESCRIPTION
## What type of change is this? (check all applicable)

- [x] Workflow change
- [ ] Workflow config / matrix change
- [ ] Deployment template / resource change
- [ ] Action or script change
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor / maintenance

## Description

Change opensearch timeout due to the fact that the tests with the allure report do not have time to pass
https://github.com/Netcracker/qubership-opensearch/actions/runs/27247688207/job/80465241839

## What is affected? (check all applicable)

- [x] `.github/workflows/*`
- [ ] `workflow-config/*`
- [ ] `templates/*`
- [ ] `actions/*`
- [ ] `scripts/*`
- [ ] `docs/*`
- [ ] `resources/*` or `restricted/*`

## Services / scenarios impacted

<!-- List affected services and changed pipeline behavior.
Examples:
- Kafka: reusable workflow + matrix for PR scope
- Consul: S3 upgrade template
-->

## Related tickets and documents

- Related Issue #
- Closes #
- Related docs / workflow reference:

## Verification

- [ ] Verified by pipeline run
- [x] Static review only
- [ ] Not verified yet

<!-- Add links or a short note on how the change was checked. -->

## Compatibility / impact

- [x] No compatibility impact
- [ ] Workflow interface changed (`inputs`, `outputs`, `secrets`, job names)
- [ ] Template parameters or behavior changed
- [ ] Test matrix / covered scenarios changed
- [ ] Existing upgrade flow or previous behavior was checked
- [ ] Documentation updated

## Additional notes (optional)
