### PR TITLE
ci: harden GitHub Actions workflows and shared actions per zizmor audit

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   assign-labels:
     name: "Assign Labels to PR #${{ github.event.pull_request.number }}"

--- a/.github/workflows/consul.yaml
+++ b/.github/workflows/consul.yaml
@@ -82,7 +82,7 @@ jobs:
       matrix: ${{ steps.process-versions.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -90,7 +90,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -147,7 +147,7 @@ jobs:
           echo "$MATRIX_JSON"
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -399,7 +399,7 @@ jobs:
     needs: [Consul-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/kafka.yaml
+++ b/.github/workflows/kafka.yaml
@@ -100,7 +100,7 @@ jobs:
       service_images: ${{ steps.parse-matrix.outputs.service_images }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -108,7 +108,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -188,7 +188,7 @@ jobs:
           echo "======== Job parameters ======="
           echo "$MATRIX_JSON"
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -710,7 +710,7 @@ jobs:
     needs: [Kafka-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -9,6 +9,9 @@ on:
     branches: [main]
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   linkChecker:
     name: Run Link Checker

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,17 +9,21 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/monitoring.yaml
+++ b/.github/workflows/monitoring.yaml
@@ -93,7 +93,7 @@ jobs:
       matrix: ${{ steps.process-versions.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -101,7 +101,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: ${{ github.repository_owner }}/qubership-test-pipelines
@@ -159,7 +159,7 @@ jobs:
           echo "$MATRIX_JSON"
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: ${{ github.repository_owner }}/qubership-test-pipelines
@@ -305,7 +305,7 @@ jobs:
     needs: [Monitoring-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/opensearch.yaml
+++ b/.github/workflows/opensearch.yaml
@@ -79,7 +79,7 @@ jobs:
       matrix: ${{ steps.process-versions.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -163,7 +163,7 @@ jobs:
           swap-storage: true
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -417,7 +417,7 @@ jobs:
     needs: [Opensearch-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/pgskipper.yaml
+++ b/.github/workflows/pgskipper.yaml
@@ -105,7 +105,7 @@ jobs:
       service_images: ${{ steps.parse-matrix.outputs.service_images }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -113,7 +113,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: ${{ github.repository_owner }}/qubership-test-pipelines
@@ -180,7 +180,7 @@ jobs:
           echo "$MATRIX_JSON"
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -446,7 +446,7 @@ jobs:
     needs: [Pgskipper-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -33,6 +33,6 @@ jobs:
           persist-credentials: false
 
       - name: Assign Reviewers
-        uses: netcracker/qubership-workflow-hub/actions/pr-assigner@5a557213e92e3d22d0292330c4817c82af6704d2 # 2.1.2
+        uses: netcracker/qubership-workflow-hub/actions/pr-assigner@5a557213e92e3d22d0292330c4817c82af6704d2 # v2.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -11,11 +11,18 @@ on:
 
 permissions:
   pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
-      - uses: webiny/action-conventional-commits@v1.3.0
+      - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0

--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -13,6 +13,10 @@ on:
 permissions:
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/profanity-filter.yaml
+++ b/.github/workflows/profanity-filter.yaml
@@ -13,6 +13,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   apply-filter:
     name: Apply Profanity Filter
@@ -20,7 +24,7 @@ jobs:
     steps:
     - name: Scan issue or pull request for profanity
       # Conditionally run the step if the actor isn't a bot
-      if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+      if: ${{ github.event.sender.type != 'Bot' }}
       uses: IEvangelist/profanity-filter@7d6e0c79ee3d33ae09b5ed0c6e2fa04b9c512e08 # 10.0
       id: profanity-filter
       with:

--- a/.github/workflows/rabbitmq.yaml
+++ b/.github/workflows/rabbitmq.yaml
@@ -81,7 +81,7 @@ jobs:
       matrix: ${{ steps.process-versions.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -89,7 +89,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -151,7 +151,7 @@ jobs:
           echo "$MATRIX_JSON"
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -373,7 +373,7 @@ jobs:
     needs: [RabbitMQ-Test-Cases]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   super-linter:
     name: Lint Code Base

--- a/.github/workflows/zookeeper.yaml
+++ b/.github/workflows/zookeeper.yaml
@@ -89,7 +89,7 @@ jobs:
       matrix: ${{ steps.process-versions.outputs.matrix }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.service_branch }}
           repository: ${{ inputs.repository_name }}
@@ -97,7 +97,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -154,7 +154,7 @@ jobs:
           echo "$MATRIX_JSON"
 
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -405,7 +405,7 @@ jobs:
     name: Clean [${{ inputs.service_branch }}] TLS
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -507,7 +507,7 @@ jobs:
     name: Clean [${{ inputs.service_branch }}] TLS Secrets
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -567,7 +567,7 @@ jobs:
     name: Clean [${{ inputs.service_branch }}] TLS Certificates
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines
@@ -626,7 +626,7 @@ jobs:
     needs: [Zookeeper-Test-Cases, Clean-Latest-TLS, Clean-Latest-TLS-Certificates, Clean-Latest-TLS-Secrets]
     steps:
       - name: Checkout pipeline
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v5.1.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.pipeline_branch }}
           repository: netcracker/qubership-test-pipelines

--- a/actions/shared/check_job_status/action.yml
+++ b/actions/shared/check_job_status/action.yml
@@ -11,11 +11,13 @@ runs:
   steps:
     - name: Check job status
       shell: bash
+      env:
+        JOB_RESULT: ${{ inputs.job_result }}
       # language=bash
       run: |
         # ▶️ Check job status
-        echo Job status: ${{inputs.job_result}}
-        if [[ ${{inputs.job_result}} == "success" || ${{inputs.job_result}} == "skipped" ]]; then
+        echo "Job status: ${JOB_RESULT}"
+        if [[ "${JOB_RESULT}" == "success" || "${JOB_RESULT}" == "skipped" ]]; then
           exit 0
         else
           exit 1

--- a/actions/shared/cleanup_s3_bucket/action.yml
+++ b/actions/shared/cleanup_s3_bucket/action.yml
@@ -14,17 +14,19 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
         aws-region: ${{ inputs.region }}
     - name: Delete bucket
       shell: bash
+      env:
+        BUCKET: ${{ inputs.bucket_name }}
+        REGION: ${{ inputs.region }}
       run: |
-        BUCKET="${{ inputs.bucket_name }}"
-        if aws s3 ls "s3://${BUCKET}" --region "${{ inputs.region }}" >/dev/null 2>&1; then
-          aws s3 rb "s3://${BUCKET}" --region "${{ inputs.region }}" --force
+        if aws s3 ls "s3://${BUCKET}" --region "${REGION}" >/dev/null 2>&1; then
+          aws s3 rb "s3://${BUCKET}" --region "${REGION}" --force
           echo "Bucket ${BUCKET} deleted"
         else
           echo "::warning:: Bucket ${BUCKET} does not exist, skipping deletion."

--- a/actions/shared/create_cluster/action.yml
+++ b/actions/shared/create_cluster/action.yml
@@ -48,10 +48,12 @@ runs:
         ./kind delete cluster --name kind || true
     - name: Run kind
       shell: bash
+      env:
+        KIND_LAYOUT: ${{ inputs.kind-layout }}
       # language=bash
       run: >-
         ./kind create cluster
         --image kindest/node:v1.32.2
-        --config qubership-test-pipelines/kind-configs/kind-${{ inputs.kind-layout }}.yaml
+        --config "qubership-test-pipelines/kind-configs/kind-${KIND_LAYOUT}.yaml"
         --wait 5m
       # ! check kubernetes version is actual

--- a/actions/shared/helm_deploy/action.yml
+++ b/actions/shared/helm_deploy/action.yml
@@ -73,31 +73,36 @@ runs:
   using: composite
   steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{inputs.service_branch}}
         repository: ${{inputs.repository_name}}
         path: ${{inputs.repository_name}}
+        persist-credentials: false
 
     - name: Create namespace
       if: inputs.deploy_mode == 'install'
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
         # ▶️ Create namespace
-        if ! kubectl get namespace ${{inputs.namespace}} >/dev/null 2>&1; then
-        kubectl create namespace ${{inputs.namespace}}
+        if ! kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+        kubectl create namespace "${NAMESPACE}"
         else
-        echo "Namespace '${{inputs.namespace}}' already exists"
+        echo "Namespace '${NAMESPACE}' already exists"
         fi
 
     - name: Create resources
       if: inputs.resource_folder != ''
       shell: bash
+      env:
+        RESOURCE_FOLDER: ${{ inputs.resource_folder }}
       # language=bash
       run: |
         # ▶️ Create resources
-        folder="qubership-test-pipelines/${{inputs.resource_folder}}"
+        folder="qubership-test-pipelines/${RESOURCE_FOLDER}"
         files=($(find "$folder" -type f))
         echo $files
         for file in "${files[@]}"; do
@@ -107,10 +112,13 @@ runs:
 
     - name: Replace CRDs
       shell: bash
+      env:
+        REPOSITORY_NAME: ${{ inputs.repository_name }}
+        PATH_TO_CHART: ${{ inputs.path_to_chart }}
       # language=bash
       run: |
         # ▶️ Replace CRDs
-        cd "${{inputs.repository_name}}/${{inputs.path_to_chart}}"
+        cd "${REPOSITORY_NAME}/${PATH_TO_CHART}"
         if [ -d "./crds" ]; then
           echo "CRDs directory exists"
           for file in ./crds/*; do
@@ -149,32 +157,40 @@ runs:
 
     - name: Copy template
       shell: bash
+      env:
+        PATH_TO_TEMPLATE: ${{ inputs.path_to_template }}
+        REPOSITORY_NAME: ${{ inputs.repository_name }}
+        PATH_TO_CHART: ${{ inputs.path_to_chart }}
       # language=bash
       run: |
         # ▶️ Copy template
-        cp qubership-test-pipelines/${{inputs.path_to_template}} ${{inputs.repository_name}}/${{inputs.path_to_chart}}
+        cp "qubership-test-pipelines/${PATH_TO_TEMPLATE}" "${REPOSITORY_NAME}/${PATH_TO_CHART}"
 
     - name: Check if version is release
       id: check-release
       shell: bash
+      env:
+        SERVICE_BRANCH: ${{ inputs.service_branch }}
       # language=bash
       run: |
         # ▶️ Check if version is release
-        if [[ "${{inputs.service_branch}}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "${{inputs.service_branch}} is release version"
+        if [[ "${SERVICE_BRANCH}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "${SERVICE_BRANCH} is release version"
           echo "is_release=true" >> $GITHUB_OUTPUT
         else
-          echo "${{inputs.service_branch}} is not release version"
+          echo "${SERVICE_BRANCH} is not release version"
           echo "is_release=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Replace slash in service branch
       id: replace_slash
       shell: bash
+      env:
+        SERVICE_BRANCH: ${{ inputs.service_branch }}
       # language=bash
       run: |
         # ▶️ Replace slash in service branch
-        service_branch="${{ inputs.service_branch }}"
+        service_branch="${SERVICE_BRANCH}"
         # if branch is a commit hash (contains from 7 up to 40 characters: digits or letters from a to f), trim to 11 characters
         if echo "$service_branch" | grep -Eq '^[0-9a-f]{7,40}$'; then
           service_branch_updated="git-${service_branch:0:7}"
@@ -187,10 +203,14 @@ runs:
     - name: Update Image Version
       if: inputs.image_replacement != ''
       shell: bash
+      env:
+        REPOSITORY_NAME: ${{ inputs.repository_name }}
+        PATH_TO_CHART: ${{ inputs.path_to_chart }}
+        IMAGE_REPLACEMENT: ${{ inputs.image_replacement }}
       run: |
         # ▶️ Replace version of service
-        path_to_file="${{inputs.repository_name}}/${{inputs.path_to_chart}}/values.yaml"
-        new_image="${{ inputs.image_replacement }}"
+        path_to_file="${REPOSITORY_NAME}/${PATH_TO_CHART}/values.yaml"
+        new_image="${IMAGE_REPLACEMENT}"
         base="${new_image%-*}"
         if [ ! -f "$path_to_file" ]; then echo "::error::File not found: $path_to_file"; exit 1; fi
         current_image=$(grep -oE "${base}-[^:\"' ]+" "$path_to_file" | head -n 1)
@@ -211,22 +231,29 @@ runs:
 
     - name: echo tags
       shell: bash
+      env:
+        TEST_TAGS: ${{ inputs.test_tags }}
       run: |
         # ▶️ Echo tags
-        new_tags="${{ inputs.test_tags }}"
+        new_tags="${TEST_TAGS}"
         echo $new_tags
 
 
     - name: Update Test Tags
       if: inputs.test_tags != ''
       shell: bash
+      env:
+        PATH_TO_TEMPLATE: ${{ inputs.path_to_template }}
+        REPOSITORY_NAME: ${{ inputs.repository_name }}
+        PATH_TO_CHART: ${{ inputs.path_to_chart }}
+        TEST_TAGS: ${{ inputs.test_tags }}
       run: |
         # ▶️ Update Test Tags
-        template_name=$(basename "${{ inputs.path_to_template }}")
+        template_name=$(basename "${PATH_TO_TEMPLATE}")
         echo "Template file: $template_name"
-        cd "${{ inputs.repository_name }}/${{ inputs.path_to_chart }}"
+        cd "${REPOSITORY_NAME}/${PATH_TO_CHART}"
         file="$template_name"
-        new_tags="${{ inputs.test_tags }}"
+        new_tags="${TEST_TAGS}"
         current_tags=$(grep -E '^[[:space:]]*tags:[[:space:]]*' "$file" | head -n1 | sed -E 's/^[[:space:]]*tags:[[:space:]]*//; s/^"//; s/"$//')
         if [ -z "$current_tags" ]; then
           echo "::warning::No 'tags' field found in $file – nothing to update."
@@ -260,24 +287,34 @@ runs:
 
     - name: Install/update service with helm
       shell: bash
+      env:
+        DEPLOY_MODE: ${{ inputs.deploy_mode }}
+        SERVICE_NAME: ${{ inputs.service_name }}
+        PATH_TO_TEMPLATE: ${{ inputs.path_to_template }}
+        REPOSITORY_NAME: ${{ inputs.repository_name }}
+        PATH_TO_CHART: ${{ inputs.path_to_chart }}
+        RESTRICTED: ${{ inputs.restricted }}
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
-        # ▶️ ${{inputs.deploy_mode}} ${{inputs.service_name}} with Helm
-        template_name=$(basename "${{inputs.path_to_template}}")
+        # ▶️ Install/update service with Helm
+        template_name=$(basename "${PATH_TO_TEMPLATE}")
         echo $template_name
-        cd ${{inputs.repository_name}}/${{inputs.path_to_chart}}
-        if [[ "${{inputs.restricted}}" == "false" ]]; then
-          helm ${{inputs.deploy_mode}} ${{inputs.service_name}} . -f $template_name -n ${{inputs.namespace}} --timeout 10m
+        cd "${REPOSITORY_NAME}/${PATH_TO_CHART}"
+        if [[ "${RESTRICTED}" == "false" ]]; then
+          helm "${DEPLOY_MODE}" "${SERVICE_NAME}" . -f "$template_name" -n "${NAMESPACE}" --timeout 10m
         else
-          helm ${{inputs.deploy_mode}} ${{inputs.service_name}} . -f $template_name -n ${{inputs.namespace}} --timeout 10m --skip-crds
+          helm "${DEPLOY_MODE}" "${SERVICE_NAME}" . -f "$template_name" -n "${NAMESPACE}" --timeout 10m --skip-crds
         fi
 
     - name: Get docker images
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
         # ▶️ Get docker images
-        kubectl get pods -n ${{inputs.namespace}} -o go-template --template="{{range .items}}{{range .spec.containers}}{{.image}} {{end}}{{end}}"
+        kubectl get pods -n "${NAMESPACE}" -o go-template --template="{{range .items}}{{range .spec.containers}}{{.image}} {{end}}{{end}}"
 
     - name: Use default context
       if: inputs.restricted == 'true'
@@ -288,7 +325,9 @@ runs:
     - name: Get resources after deploy
       if: always()
       shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
       # language=bash
       run: |
         # ▶️ Get resources after deploy
-        kubectl get all -n ${{inputs.namespace}}
+        kubectl get all -n "${NAMESPACE}"

--- a/actions/shared/helm_deploy/action.yml
+++ b/actions/shared/helm_deploy/action.yml
@@ -275,7 +275,7 @@ runs:
     - name: Update versions in values
       id: update-versions
       if: ${{ steps.check-release.outputs.is_release == 'false' }}
-      uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@d558e10a6537924292e7dd7ff4109c2bda9b406e # v2.0.5
+      uses: netcracker/qubership-workflow-hub/actions/charts-values-update-action@396774180000abdb825cbf150b56cc59c6913db8 # v2.0.5
       with:
         release-version: ${{steps.replace_slash.outputs.service_branch_updated}}
         config-file: .github/charts-values-update-config.yaml

--- a/actions/shared/setup_s3_bucket/action.yml
+++ b/actions/shared/setup_s3_bucket/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-access-key-id: ${{ inputs.aws_access_key_id }}
         aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
@@ -30,8 +30,11 @@ runs:
     - name: Create bucket
       id: create
       shell: bash
+      env:
+        PREFIX: ${{ inputs.prefix }}
+        REGION: ${{ inputs.region }}
       run: |
         TIMESTAMP=$(date +'%Y%m%d%H%M%S')
-        BUCKET_NAME="test-pipelines-${{ inputs.prefix }}-${TIMESTAMP}"
-        aws s3 mb "s3://${BUCKET_NAME}" --region "${{ inputs.region }}"
+        BUCKET_NAME="test-pipelines-${PREFIX}-${TIMESTAMP}"
+        aws s3 mb "s3://${BUCKET_NAME}" --region "${REGION}"
         echo "bucket_name=${BUCKET_NAME}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What type of change is this? (check all applicable)

- [x] Workflow change
- [x] Action or script change
- [x] Refactor / maintenance

## Description

Security hardening pass across all GitHub Actions workflows and shared composite
actions based on a full zizmor audit. Fixes template-injection risks (move
`${{ inputs.* }}` interpolations into `env:` vars), pins/repins action SHAs to
match their tags (ref-version-mismatch), adds `persist-credentials: false` to
checkout steps (artipacked), adds missing `concurrency` groups, and fixes a
`bot-conditions` check in profanity-filter.

## What is affected? (check all applicable)

- [x] `.github/workflows/*`
- [x] `actions/*`

## Services / scenarios impacted

- consul, kafka, monitoring, opensearch, pgskipper, rabbitmq, zookeeper:
  re-pinned `actions/checkout` SHA comments to match actual tags
- pr-conventional-commits, lint, automatic-pr-labeler, link-checker,
  pr-lint-title, profanity-filter, super-linter: added concurrency groups
  and/or SHA pins
- pr-assigner: fixed version comment mismatch
- profanity-filter: replaced actor-string bot check with
  `github.event.sender.type != 'Bot'`
- actions/shared/helm_deploy, cleanup_s3_bucket, setup_s3_bucket,
  check_job_status, create_cluster: moved `${{ inputs.* }}` interpolations
  in `run:` blocks into step-level `env:` vars to fix template-injection
  findings; added `persist-credentials: false` to helm_deploy checkout step

## Related tickets and documents

- Related Issue #
- Closes #
- Related docs / workflow reference: zizmor security audit findings

## Verification

- [x] Static review only

zizmor audit re-run confirmed all reported template-injection,
artipacked, ref-version-mismatch, and concurrency-limits findings resolved.

## Compatibility / impact

- [x] No compatibility impact

## Additional notes (optional)

None.