### PR TITLE
feat: support hardened Kind admission plugins

### DIFF
--- a/.github/workflows/monitoring.yaml
+++ b/.github/workflows/monitoring.yaml
@@ -30,6 +30,11 @@ on:
         type: string
         required: false
         default: multi-node
+      enable-owner-references-permission-enforcement:
+        description: Enable OwnerReferencesPermissionEnforcement in the Kind API server
+        type: boolean
+        required: false
+        default: false
       scope:
         description: Monitoring Test Scope (pr, nightly or hardening)
         type: string
@@ -77,6 +82,11 @@ on:
         type: string
         required: false
         default: multi-node
+      enable-owner-references-permission-enforcement:
+        description: Enable OwnerReferencesPermissionEnforcement in the Kind API server
+        type: boolean
+        required: false
+        default: false
       scope:
         description: Monitoring Test Scope (pr, nightly or hardening)
         type: string
@@ -201,6 +211,7 @@ jobs:
         uses: ./qubership-test-pipelines/actions/shared/create_cluster
         with:
           kind-layout: ${{ inputs.kind-layout }}
+          enable-owner-references-permission-enforcement: ${{ inputs.enable-owner-references-permission-enforcement }}
 
       # == Start ======= Specific steps for Allure report =======
       - name: Check Allure configuration

--- a/actions/shared/create_cluster/README.md
+++ b/actions/shared/create_cluster/README.md
@@ -19,4 +19,8 @@ jobs:
     steps:
       - name: Create Kubernetes Cluster
         uses: Netcracker/qubership-test-pipelines/actions/shared/create_cluster@main
+        with:
+          enable-owner-references-permission-enforcement: true
 ```
+
+The `enable-owner-references-permission-enforcement` input is disabled by default. When enabled, the action uses a Kind configuration that preserves Kind's `NodeRestriction` admission plugin and adds `OwnerReferencesPermissionEnforcement`.

--- a/actions/shared/create_cluster/action.yml
+++ b/actions/shared/create_cluster/action.yml
@@ -6,6 +6,11 @@ inputs:
       Kind cluster layout (single-node or multi-node)
     required: false
     default: multi-node
+  enable-owner-references-permission-enforcement:
+    description: |
+      Enable OwnerReferencesPermissionEnforcement in the Kind API server
+    required: false
+    default: "false"
 runs:
   using: composite
   steps:
@@ -50,10 +55,16 @@ runs:
       shell: bash
       env:
         KIND_LAYOUT: ${{ inputs.kind-layout }}
+        ENABLE_OWNER_REFERENCES_PERMISSION_ENFORCEMENT: ${{ inputs.enable-owner-references-permission-enforcement }}
       # language=bash
-      run: >-
-        ./kind create cluster
-        --image kindest/node:v1.32.2
-        --config "qubership-test-pipelines/kind-configs/kind-${KIND_LAYOUT}.yaml"
-        --wait 5m
+      run: |
+        KIND_CONFIG="qubership-test-pipelines/kind-configs/kind-${KIND_LAYOUT}"
+        if [[ "$ENABLE_OWNER_REFERENCES_PERMISSION_ENFORCEMENT" == "true" ]]; then
+          KIND_CONFIG+="-ownerrefs"
+        fi
+        KIND_CONFIG+=".yaml"
+        ./kind create cluster \
+          --image kindest/node:v1.32.2 \
+          --config "$KIND_CONFIG" \
+          --wait 5m
       # ! check kubernetes version is actual

--- a/actions/shared/get_crds/action.yaml
+++ b/actions/shared/get_crds/action.yaml
@@ -29,7 +29,7 @@ runs:
           yml_kind=$(yq e '.kind' $yaml)
           if [ "$yml_kind" == "CustomResourceDefinition" ]; then
             crd_name=$(yq e '.metadata.name' $yaml)
-            CRDS_ARRAY+=$crd_name
+            CRDS_ARRAY+=("$crd_name")
           fi
         done
         CRDS=${CRDS_ARRAY[*]}

--- a/kind-configs/kind-multi-node-ownerrefs.yaml
+++ b/kind-configs/kind-multi-node-ownerrefs.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  apiServer:
+    extraArgs:
+      # extraArgs replaces the flag rather than merging into it, so
+      # NodeRestriction — Kind's own default — must be repeated here.
+      enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kind-configs/kind-single-node-ownerrefs.yaml
+++ b/kind-configs/kind-single-node-ownerrefs.yaml
@@ -1,0 +1,36 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  apiServer:
+    extraArgs:
+      # extraArgs replaces the flag rather than merging into it, so
+      # NodeRestriction — Kind's own default — must be repeated here.
+      enable-admission-plugins: NodeRestriction,OwnerReferencesPermissionEnforcement
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  - |
+    kind: ClusterConfiguration
+    etcd:
+      local:
+        serverCertSANs:
+          - "localhost"
+          - "kind-control-plane"
+          - "127.0.0.1"
+          - "172.18.0.3"
+          - "172.19.0.2"
+          - "172.19.0.3"
+        peerCertSANs:
+          - "localhost"
+          - "kind-control-plane"
+          - "127.0.0.1"
+          - "172.18.0.3"
+          - "172.19.0.2"
+          - "172.19.0.3"


### PR DESCRIPTION
## Why this matters

The monitoring integration pipeline is a shared test platform for multiple service streams. A default Kind cluster does not enforce `OwnerReferencesPermissionEnforcement`, while Kubernetes and OpenShift environments may enforce owner-reference permissions. This can let an operator pass CI with incomplete RBAC and fail later in a production-like cluster when it creates or updates owned resources.

The opt-in hardened mode makes the integration environment closer to the clusters where the operator runs. It turns missing owner-reference permissions into an early, actionable CI failure and gives service teams a reusable way to validate RBAC-sensitive changes before they reach shared environments.

## What changes

- add an opt-in `enable-owner-references-permission-enforcement` input to the Kind cluster action;
- preserve Kind's `NodeRestriction` plugin while enabling `OwnerReferencesPermissionEnforcement`;
- add single-node and multi-node hardened Kind configurations;
- preserve existing callers and default layouts through safe defaults.

## Validation

Validated locally with `act` and Kind `v0.25.0` using `kindest/node:v1.32.2`:

- single-node, default admission configuration: passed;
- single-node, hardened admission configuration: passed;
- multi-node, hardened admission configuration: passed;
- existing default Kind layouts: remain unchanged when the new input is disabled;
- hardened Kind layouts: select the new admission configuration when the input is enabled.

The hardened configuration repeats `NodeRestriction` because `extraArgs` replaces the API-server flag rather than merging with Kind's defaults. The current Kind node image requires `extraArgs` in map form.
